### PR TITLE
Fix _field_type typo

### DIFF
--- a/wepitopes/models/db_collections.py
+++ b/wepitopes/models/db_collections.py
@@ -45,7 +45,7 @@ class VirusSequences(COL.Collection):
   }
 
   _field_types = {
-      'Index': 'floar',
+      'Index': 'float',
       'Accession': "enumeration",
       # 'Sequence': "enumeration",
       'Version': "enumeration",


### PR DESCRIPTION
The `Index` field from the `VirusSequences` class had an incorrect `floar` type instead of `float`